### PR TITLE
Reduce priority for PrivateNetwork

### DIFF
--- a/meshSidecar.nix
+++ b/meshSidecar.nix
@@ -107,7 +107,7 @@
           then "netbird@%N.service"
           else "tailscale@%N.service";
         # doesn't change based on mesh provider
-        serviceConfig.PrivateNetwork = true;
+        serviceConfig.PrivateNetwork = lib.mkDefault true;
         serviceConfig.BindPaths = ["/etc/netns/%N/resolv.conf:/etc/resolv.conf"];
       })
       cfg.services;


### PR DESCRIPTION
For context: I tried to wrap the `paperless-web` service which originates from the `services.paperless` module.
 
The `serviceConfig.PrivateNetwork` setting conflicted with my wrapped service, so the evaluation failed. Reducing its priority lead to it being overwritten by the original service. I am not sure if you rely on it being `true` otherwise this is probably a good fix.