### PR TITLE
Merge JoinsNamespaceOf

### DIFF
--- a/meshSidecar.nix
+++ b/meshSidecar.nix
@@ -104,8 +104,8 @@
           else ["tailscale@%N.service"];
         unitConfig.JoinsNamespaceOf =
           if cfg.provider == "netbird"
-          then "netbird@%N.service"
-          else "tailscale@%N.service";
+          then lib.mkAfter ["netbird@%N.service"]
+          else lib.mkAfter ["tailscale@%N.service"];
         # doesn't change based on mesh provider
         serviceConfig.PrivateNetwork = true;
         serviceConfig.BindPaths = ["/etc/netns/%N/resolv.conf:/etc/resolv.conf"];


### PR DESCRIPTION
In my scenario the paperless module already defined multiple services that were joining each other in their namespace. So there was a conflict during evaluation. This simply ensures the setting is appended.